### PR TITLE
Update service cards

### DIFF
--- a/content/services/CollegeAdmissions/index.md
+++ b/content/services/CollegeAdmissions/index.md
@@ -1,7 +1,7 @@
 ---
 title: College Admissions
-external_link: https://github.com/pytorch/pytorch
-date: 2025-07-24
+link: /college-admissions/
+show_date_updated: false
 tags:
   - Hugo
   - Wowchemy

--- a/content/services/TestPrep/index.md
+++ b/content/services/TestPrep/index.md
@@ -1,7 +1,7 @@
 ---
 title: Test Prep
-external_link: https://github.com/pandas-dev/pandas
-date: 2025-07-24
+link: /test-prep/
+show_date_updated: false
 tags:
   - Hugo
   - Wowchemy

--- a/layouts/partials/views/article-grid.html
+++ b/layouts/partials/views/article-grid.html
@@ -1,0 +1,97 @@
+{{ $item := .item }}
+{{ $fill_image := .config.fill_image | default true }}
+
+{{ $resource := partial "functions/get_featured_image.html" $item }}
+{{ $anchor := $item.Params.image.focal_point | default "Center" }}
+
+{{ $link := $item.Params.link | default $item.Params.external_link | default $item.RelPermalink }}
+{{ $target := "" }}
+{{ if $item.Params.external_link }}
+  {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+{{ end }}
+
+<div class="group cursor-pointer">
+
+  {{ with $resource }}
+  {{ $image := "" }}
+  {{if $fill_image}}
+    {{ $image = .Fill (printf "960x540 %s" $anchor) }}
+  {{else}}
+    {{ $image = .Fit (printf "960x540 %s" $anchor) }}
+  {{end}}
+  {{ if ne $image.MediaType.SubType "gif" }}{{ $image = $image.Process "webp" }}{{ end }}
+  <div class="overflow-hidden rounded-md bg-gray-100 transition-all hover:scale-105 dark:bg-gray-800">
+
+    <a
+      class="relative block aspect-video"
+      href="{{ $link }}" {{ $target | safeHTMLAttr }}>
+
+      <img alt="{{ $item.Title | plainify }}"
+           class="{{if $fill_image}}object-fill{{else}}object-contain{{end}} transition-all"
+           data-nimg="fill"
+           decoding="async"
+           fetchpriority="high" height="{{ $image.Height }}" loading="lazy" src="{{ $image.RelPermalink }}"
+           style="position: absolute; height: 100%; width: 100%; inset: 0px; color: transparent;"
+           width="{{ $image.Width }}"></a>
+  </div>
+  {{end}}
+  <div class="">
+    <div class="">
+      <div class="flex gap-3">
+        {{ range $index, $value := first 1 ($item.GetTerms "tags") }}
+        <a href="{{.RelPermalink}}"><span
+          class="inline-block text-xs font-medium tracking-wider uppercase mt-5 text-primary-700 dark:text-primary-300">{{ .Page.LinkTitle }}</span></a>
+        {{end}}
+      </div>
+      <!--          <div class="relative line-clamp-2" style="display: block; height: 4em">-->
+      <h2 class="text-lg font-semibold leading-snug tracking-tight mt-2 dark:text-white"><a
+        href="{{ $link }}" {{ $target | safeHTMLAttr }}><span
+        class="bg-gradient-to-r from-primary-200 to-primary-100 bg-[length:0px_10px] bg-left-bottom bg-no-repeat transition-[background-size] duration-500 hover:bg-[length:100%_3px] group-hover:bg-[length:100%_10px] dark:from-primary-800 dark:to-primary-900">
+           {{- $item.Title -}}
+           {{if $target}}{{ partial "functions/get_icon" (dict "name" "arrow-top-right-on-square" "attributes" "style=\"height: 1em;\" class=\"inline-flex h-6 w-6 pl-2\"")  }}{{end}}
+          </span></a>
+      </h2>
+      <!--          </div>-->
+      <div class="grow"><p class="mt-2 line-clamp-3 text-sm text-gray-500 dark:text-gray-400"><a
+        href="{{ $link }}" {{ $target | safeHTMLAttr }}>
+        {{ ($item.Params.summary | default $item.Summary) | plainify | htmlUnescape | chomp -}}
+      </a></p>
+      </div>
+      <div class="flex-none">
+        <div class="mt-3 flex items-center space-x-3 text-gray-500 dark:text-gray-400 cursor-default">
+          <!--          <a href="">-->
+          {{ if .Params.authors }}
+          <div class="flex items-center gap-3">
+            {{ range $index, $value := first 1 ($item.GetTerms "authors") }}
+            <div class="relative h-5 w-5 flex-shrink-0">
+              {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
+              {{ $authorImage := $avatar.Process "Fill 50x50 Center 95 webp" }}
+              <img alt="avatar"
+                   class="rounded-full object-cover"
+                   data-nimg="fill"
+                   decoding="async" height="{{$authorImage.Height}}"
+                   loading="lazy"
+                   sizes="20px"
+                   src="{{$authorImage.RelPermalink}}"
+                   style="position: absolute; height: 100%; width: 100%; inset: 0px; color: transparent;"
+                   width="{{$authorImage.Width}}">
+            </div>
+            <span class="truncate text-sm">
+                {{- .Page.LinkTitle -}}
+              </span>
+          </div>
+          {{end}}
+          <!--          </a>-->
+          <span class="text-xs text-gray-300 dark:text-gray-600">•</span>
+          {{end}}
+          {{ if not $item.Date.IsZero }}
+          <time class="truncate text-sm" datetime="{{ time.Format "2006-01-02" $item.Date }}">
+          {{- $item.Date | time.Format (site.Params.locale.date_format | default ":date_long") -}}
+          </time>
+          {{ end }}
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- allow service cards to link via `link` param
- suppress dates on service cards when none is provided
- update CollegeAdmissions and TestPrep content to use new param

## Testing
- `go mod download`

------
https://chatgpt.com/codex/tasks/task_e_6882af936948832cbf3beb27f1b2c452