### PR TITLE
Hide schedule page title

### DIFF
--- a/assets/css/calendly.css
+++ b/assets/css/calendly.css
@@ -7,6 +7,10 @@
   height:100%;
   min-width:320px;  /* mobile floor */
 }
+
+.page-body h1 {
+  display: none;
+}
 @media (max-width:640px){
   .calendly-wrapper{
     min-height:calc(100vh - var(--navbar-height));

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -4,6 +4,7 @@ type: page
 share: false
 pager: false
 reading_time: false
+hide_date: true
 css: ["calendly.css"]  # load custom styles defined below
 ---
 


### PR DESCRIPTION
## Summary
- hide date on schedule page
- hide schedule page title via page-specific CSS

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68b4d69268cc832cb6d8b8fce4a4a0e8