### PR TITLE
Update SEO metadata for local business

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -11,10 +11,10 @@ appearance:
 # SEO
 marketing:
   seo:
-    site_type: Person
-    local_business_type: ''
-    org_name: ''
-    description: 'Get in contact with Cassidy Artz to change your life with acceptance into your dream school.'
+    site_type: LocalBusiness
+    local_business_type: EducationalService
+    org_name: 'Cassidy Artz'
+    description: 'Connect with Cassidy Artz for personalized test prep and admissions coaching to help you win admission to top schools with clarity, strategy, and confidence.'
   analytics:
     google_analytics: 'G-Y17JRC510E'
   verification:


### PR DESCRIPTION
### Motivation
- Reclassify the site from a personal profile to a local educational business to improve structured data and SEO.
- Provide a clear organization name for better branding and search results.
- Replace a generic description with a targeted service-focused message for test prep and admissions coaching.

### Description
- Update `marketing.seo.site_type` from `Person` to `LocalBusiness` in `config/_default/params.yaml`.
- Set `marketing.seo.local_business_type` to `EducationalService` and `marketing.seo.org_name` to `'Cassidy Artz'`.
- Replace the SEO `description` with a tailored message about personalized test prep and admissions coaching.
- Preserve the existing analytics ID at `marketing.analytics.google_analytics` (`'G-Y17JRC510E'`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696298b18520832caf54f33e62b51df3)