### PR TITLE
Add robots.txt and sitemap defaults; remove empty Google verification placeholder

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -54,3 +54,6 @@ security:
   _merge: deep
 sitemap:
   _merge: deep
+  changefreq: weekly
+  priority: 0.5
+  filename: sitemap.xml

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -17,8 +17,6 @@ marketing:
     description: 'Connect with Cassidy Artz for personalized test prep and admissions coaching to help you win admission to top schools with clarity, strategy, and confidence.'
   analytics:
     google_analytics: 'G-Y17JRC510E'
-  verification:
-    google: ''
 
 # Site header
 header:

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
### Motivation
- Ensure search engines can crawl the site and discover pages via an explicit `robots.txt` that references the sitemap.
- Provide Hugo with sensible sitemap defaults so generated `sitemap.xml` has `changefreq` and `priority` values.
- Remove an unused `verification.google` placeholder because domain verification is performed via DNS and the empty token is unnecessary.
- Prepare to prioritize content for Test Prep, College Admissions, and Testimonials as the next SEO/content focus.

### Description
- Added `layouts/robots.txt` that allows all user agents and includes `Sitemap: {{ "sitemap.xml" | absURL }}`.
- Updated `config/_default/hugo.yaml` to set sitemap defaults: `changefreq: weekly`, `priority: 0.5`, and `filename: sitemap.xml`.
- Removed the empty `verification.google` entry from `config/_default/params.yaml` to avoid an unused placeholder.

### Testing
- No automated tests were run for these changes because they are static configuration and template updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a37060a8832c82790382a9a774cd)