### PR TITLE
Add canonical domain redirects and SEO/site metadata updates

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -54,3 +54,6 @@ security:
   _merge: deep
 sitemap:
   _merge: deep
+  changefreq: weekly
+  priority: 0.5
+  filename: sitemap.xml

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -17,8 +17,6 @@ marketing:
     description: 'Connect with Cassidy Artz for personalized test prep and admissions coaching to help you win admission to top schools with clarity, strategy, and confidence.'
   analytics:
     google_analytics: 'G-Y17JRC510E'
-  verification:
-    google: ''
 
 # Site header
 header:

--- a/content/college-admissions.md
+++ b/content/college-admissions.md
@@ -1,9 +1,13 @@
 ---
-title: "College Admissions"
+title: "College Admissions Coaching"
 date: 2025-07-24
-summary: Comprehensive college application guidance
+summary: Online college admissions coaching for school lists, essays, and application strategy.
 pager: false
+seo:
+  title: "College Admissions Coaching Online | {brand}"
 ---
+
+## What's included
 
 Cassidy also provides college application support, including:
 
@@ -11,6 +15,8 @@ Cassidy also provides college application support, including:
 - Essay coaching and editing
 - Timeline planning and accountability
 - Application guidance from start to finish
+
+## Recent student outcomes
 
 Her students have gained admission to top schools such as:
 - Princeton

--- a/content/test-prep.md
+++ b/content/test-prep.md
@@ -1,9 +1,13 @@
 ---
-title: "Test Prep"
+title: "SAT/ACT Test Prep"
 date: 2025-07-24
-summary: One-on-one SAT and ACT tutoring
+summary: Online one-on-one SAT/ACT test prep with personalized strategy and score improvement support.
 pager: false
+seo:
+  title: "SAT/ACT Test Prep Online | {brand}"
 ---
+
+## What's included
 
 Cassidy offers one-on-one tutoring for:
 

--- a/content/testimonials/_index.md
+++ b/content/testimonials/_index.md
@@ -1,7 +1,9 @@
 ---
-title: Testimonials
-summary: Student Reviews And Outcomes
+title: Success Stories
+summary: Real student outcomes from online SAT/ACT test prep and college admissions coaching.
 type: landing
+seo:
+  title: "Success Stories | {brand}"
 
 cascade:
   - _target:
@@ -12,8 +14,8 @@ cascade:
 sections:
   - block: testimonials
     content:
-      title: Testimonials
-      subtitle: What my customers have to say about me
+      title: Success Stories
+      subtitle: Real student outcomes from online SAT/ACT test prep and admissions coaching
       items:
         - name: Olivia R. – Atlanta, GA
           text: "*Cassidy turned my test anxiety into confidence. My SAT went up 210 points after working with her for just two months. She explains things in a way that just clicks.*"

--- a/layouts/partials/jsonld/main.html
+++ b/layouts/partials/jsonld/main.html
@@ -1,0 +1,49 @@
+{{ $page := .page }}
+{{ $summary := .summary }}
+{{ $site_type := site.Params.marketing.seo.site_type | default "Person" }}
+
+{{ partialCached "jsonld/website.html" $page }}
+
+{{ if ne $site_type "Person" }}
+  {{ partial "jsonld/business.html" $page }}
+{{ end }}
+
+{{- if $page.IsPage -}}
+
+  {{ if (eq $page.Type "blog") | or (eq $page.Type "publication") | or (eq $page.Type "project") }}
+    {{ partial "jsonld/article.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+  {{ if eq $page.Type "event" }}
+    {{ partial "jsonld/event.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+{{- end -}}
+
+{{ if not $page.IsHome }}
+  {{ $crumbs := slice }}
+  {{ $crumbs = $crumbs | append (dict "name" "Home" "url" site.Home.Permalink) }}
+  {{ range $page.Ancestors.Reverse }}
+    {{ if and (ne .RelPermalink "/") (ne .Title "") }}
+      {{ $crumbs = $crumbs | append (dict "name" .Title "url" .Permalink) }}
+    {{ end }}
+  {{ end }}
+  {{ $crumbs = $crumbs | append (dict "name" $page.Title "url" $page.Permalink) }}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {{- range $index, $crumb := $crumbs -}}
+        {{- if $index }},{{ end }}
+        {
+          "@type": "ListItem",
+          "position": {{ add $index 1 }},
+          "name": {{ $crumb.name | jsonify }},
+          "item": {{ $crumb.url | jsonify }}
+        }
+        {{- end -}}
+      ]
+    }
+  </script>
+{{ end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,3 @@
+http://cassidyartz.com/* https://cassidyartz.com/:splat 301!
+http://www.cassidyartz.com/* https://cassidyartz.com/:splat 301!
+https://www.cassidyartz.com/* https://cassidyartz.com/:splat 301!


### PR DESCRIPTION
### Motivation
- Enforce a single canonical domain and HTTPS to avoid duplicate-site indexing and improve SEO.
- Provide sitewide structured data and breadcrumbs so search engines can better understand site structure.
- Ensure search engines can crawl the site via an explicit `robots.txt` and sensible sitemap defaults.
- Improve on-page SEO messaging for priority pages (test prep, college admissions, testimonials/success stories).

### Description
- Added Netlify redirect rules in `static/_redirects` to force `https` and the non-`www` canonical domain for `cassidyartz.com`.
- Added `layouts/partials/jsonld/main.html` to emit `WebSite`/`LocalBusiness` JSON-LD and to render a `BreadcrumbList` on non-home pages.
- Added `layouts/robots.txt` and updated `config/_default/hugo.yaml` to set sitemap defaults (`changefreq: weekly`, `priority: 0.5`, `filename: sitemap.xml`).
- Updated `config/_default/params.yaml` to remove the empty Google verification entry and adjusted content files (`content/test-prep.md`, `content/college-admissions.md`, `content/testimonials/_index.md`) with stronger titles, summaries, and `seo.title` front matter.

### Testing
- No automated tests were run for these changes.
- The Netlify/Hugo site build (per `netlify.toml`) was not executed as part of this PR and should be run in CI to validate template rendering and redirects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a37060a8832c82790382a9a774cd)