### PR TITLE
Homepage CTA -> Schedule a Call; update Calendly, content, and SEO assets

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -54,3 +54,6 @@ security:
   _merge: deep
 sitemap:
   _merge: deep
+  changefreq: weekly
+  priority: 0.5
+  filename: sitemap.xml

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -17,8 +17,6 @@ marketing:
     description: 'Connect with Cassidy Artz for personalized test prep and admissions coaching to help you win admission to top schools with clarity, strategy, and confidence.'
   analytics:
     google_analytics: 'G-Y17JRC510E'
-  verification:
-    google: ''
 
 # Site header
 header:

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,11 +13,11 @@ sections:
     content:
       username: admin
       text: |
-        Cassidy Artz is a nationally experienced SAT/ACT Tutor and College Admissions Advisor who has helped hundreds of students achieve their academic goals since 2010. With a background in psychology from Northwestern University and a Master of Public Health from Emory University, Cassidy combines educational expertise with deep empathy and a personalized approach to learning. She specializes in working with students of all learning styles—including those with ADHD, test anxiety, and learning differences—and is known for her calm presence, strategic insights, and outstanding results.
+        Cassidy Artz is a nationally experienced SAT/ACT Tutor and College Admissions Advisor who has helped hundreds of students achieve their academic goals since 2010. She offers SAT/ACT Test Prep Online with personalized strategies that work for every learning style—including students with ADHD, test anxiety, and learning differences. With a background in psychology from Northwestern University and a Master of Public Health from Emory University, Cassidy combines educational expertise with deep empathy and a calm, results-driven approach for families across the country.
         <br>
       button:
-        text: Download CV
-        url: uploads/resume.pdf
+        text: Schedule a Call
+        url: /schedule/
     design:
       css_class: dark
       background:
@@ -48,4 +48,15 @@ sections:
       view: article-grid
       fill_image: false
       columns: 2
+  - block: markdown
+    content:
+      title: Get Started
+      text: |-
+        Explore the core services and success stories:
+
+        - [SAT/ACT Test Prep Online](/test-prep/)
+        - [College Admissions Coaching Online](/college-admissions/)
+        - [Success Stories](/testimonials/)
+    design:
+      columns: '1'
 ---

--- a/content/college-admissions.md
+++ b/content/college-admissions.md
@@ -1,9 +1,13 @@
 ---
-title: "College Admissions"
+title: "College Admissions Coaching"
 date: 2025-07-24
-summary: Comprehensive college application guidance
+summary: Online college admissions coaching for school lists, essays, and application strategy.
 pager: false
+seo:
+  title: "College Admissions Coaching Online | {brand}"
 ---
+
+## What's included
 
 Cassidy also provides college application support, including:
 
@@ -11,6 +15,8 @@ Cassidy also provides college application support, including:
 - Essay coaching and editing
 - Timeline planning and accountability
 - Application guidance from start to finish
+
+## Recent student outcomes
 
 Her students have gained admission to top schools such as:
 - Princeton

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -10,6 +10,5 @@ pager: false
 reading_time: false
 hide_date: true
 css: ["calendly.css"]  # load custom styles defined below
-embed_url: "https://calendly.com/cassidyartz/Tutoring"
+embed_url: "https://calendly.com/cassidyartz/lead-generation"
 ---
-

--- a/content/test-prep.md
+++ b/content/test-prep.md
@@ -1,9 +1,13 @@
 ---
-title: "Test Prep"
+title: "SAT/ACT Test Prep"
 date: 2025-07-24
-summary: One-on-one SAT and ACT tutoring
+summary: Online one-on-one SAT/ACT test prep with personalized strategy and score improvement support.
 pager: false
+seo:
+  title: "SAT/ACT Test Prep Online | {brand}"
 ---
+
+## What's included
 
 Cassidy offers one-on-one tutoring for:
 

--- a/content/testimonials/_index.md
+++ b/content/testimonials/_index.md
@@ -1,7 +1,9 @@
 ---
-title: Testimonials
-summary: Student Reviews And Outcomes
+title: Success Stories
+summary: Real student outcomes from online SAT/ACT test prep and college admissions coaching.
 type: landing
+seo:
+  title: "Success Stories | {brand}"
 
 cascade:
   - _target:
@@ -12,8 +14,8 @@ cascade:
 sections:
   - block: testimonials
     content:
-      title: Testimonials
-      subtitle: What my customers have to say about me
+      title: Success Stories
+      subtitle: Real student outcomes from online SAT/ACT test prep and admissions coaching
       items:
         - name: Olivia R. – Atlanta, GA
           text: "*Cassidy turned my test anxiety into confidence. My SAT went up 210 points after working with her for just two months. She explains things in a way that just clicks.*"

--- a/layouts/partials/jsonld/main.html
+++ b/layouts/partials/jsonld/main.html
@@ -1,0 +1,49 @@
+{{ $page := .page }}
+{{ $summary := .summary }}
+{{ $site_type := site.Params.marketing.seo.site_type | default "Person" }}
+
+{{ partialCached "jsonld/website.html" $page }}
+
+{{ if ne $site_type "Person" }}
+  {{ partial "jsonld/business.html" $page }}
+{{ end }}
+
+{{- if $page.IsPage -}}
+
+  {{ if (eq $page.Type "blog") | or (eq $page.Type "publication") | or (eq $page.Type "project") }}
+    {{ partial "jsonld/article.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+  {{ if eq $page.Type "event" }}
+    {{ partial "jsonld/event.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+{{- end -}}
+
+{{ if not $page.IsHome }}
+  {{ $crumbs := slice }}
+  {{ $crumbs = $crumbs | append (dict "name" "Home" "url" site.Home.Permalink) }}
+  {{ range $page.Ancestors.Reverse }}
+    {{ if and (ne .RelPermalink "/") (ne .Title "") }}
+      {{ $crumbs = $crumbs | append (dict "name" .Title "url" .Permalink) }}
+    {{ end }}
+  {{ end }}
+  {{ $crumbs = $crumbs | append (dict "name" $page.Title "url" $page.Permalink) }}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {{- range $index, $crumb := $crumbs -}}
+        {{- if $index }},{{ end }}
+        {
+          "@type": "ListItem",
+          "position": {{ add $index 1 }},
+          "name": {{ $crumb.name | jsonify }},
+          "item": {{ $crumb.url | jsonify }}
+        }
+        {{- end -}}
+      ]
+    }
+  </script>
+{{ end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,3 @@
+http://cassidyartz.com/* https://cassidyartz.com/:splat 301!
+http://www.cassidyartz.com/* https://cassidyartz.com/:splat 301!
+https://www.cassidyartz.com/* https://cassidyartz.com/:splat 301!


### PR DESCRIPTION
### Motivation
- Make the primary homepage CTA explicitly schedule a call and highlight `SAT/ACT Test Prep Online` and nationwide online availability.
- Improve discoverability and SEO by adding structured data, breadcrumbs, and sensible sitemap defaults.
- Strengthen page titles, summaries, and internal linking for priority pages (test prep, college admissions, testimonials).
- Enforce a single canonical domain and provide a `robots.txt` and redirects so search engines can crawl the site reliably.

### Description
- Updated `content/_index.md` hero copy to mention `SAT/ACT Test Prep Online`, changed the hero button text to `Schedule a Call` (linking to `/schedule/`), and added a `Get Started` block with internal links to `/test-prep/`, `/college-admissions/`, and `/testimonials/`.
- Updated `content/schedule.md` to use the new Calendly embed URL `https://calendly.com/cassidyartz/lead-generation` for scheduling.
- Improved SEO front matter and content for `content/test-prep.md`, `content/college-admissions.md`, and `content/testimonials/_index.md` by updating titles, summaries, and adding `seo.title` entries.
- Added `layouts/partials/jsonld/main.html` for site/business JSON-LD and breadcrumbs, added `layouts/robots.txt`, added `static/_redirects` to force the non-`www` canonical domain, set sitemap defaults in `config/_default/hugo.yaml`, and removed an empty Google verification entry from `config/_default/params.yaml`.

### Testing
- Attempted to run `hugo server --bind 0.0.0.0 --port 1313 --disableFastRender`, which failed because `hugo` is not installed in the environment.
- No automated tests were executed for these content and template updates.
- Content changes were staged and committed locally using `git commit`, which succeeded.
- A site build/CI run is recommended to validate template rendering, redirects, and the Calendly embed in a full Hugo/Netlify environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a37060a8832c82790382a9a774cd)