### PR TITLE
Restore schedule Calendly URL

### DIFF
--- a/content/schedule.md
+++ b/content/schedule.md
@@ -10,5 +10,5 @@ pager: false
 reading_time: false
 hide_date: true
 css: ["calendly.css"]  # load custom styles defined below
-embed_url: "https://calendly.com/cassidyartz/lead-generation"
+embed_url: "https://calendly.com/cassidyartz/Tutoring"
 ---


### PR DESCRIPTION
### Motivation

- The schedule page was linking to the wrong Calendly/hosted URL and previously pointed to a local/ngrok or incorrect route. 
- The intent is to restore the working scheduling embed so the site loads the correct Calendly event. 

### Description

- Reverted the `embed_url` in `content/schedule.md` to the tutoring Calendly link by changing `embed_url` to `https://calendly.com/cassidyartz/Tutoring`.
- The change modifies `content/schedule.md` only and keeps the existing embed templates (`layouts/_default/embed.html` and `layouts/embed/single.html`) intact so the page uses the `embed_url` parameter.
- Commit recorded with message `Restore schedule Calendly URL`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b1975b8c832c9eaf00abcddd86f5)